### PR TITLE
utf8: Specify [[fallthrough]] attribute

### DIFF
--- a/src/utf8.cc
+++ b/src/utf8.cc
@@ -22,7 +22,7 @@
 #define SEQ_END(n) SEQ_ ## n ## _END
 
 #define SEQ1_HELPER(s, r0)                                     \
-case (s * 4) + 0: if (r0) return 0;                            \
+case (s * 4) + 0: if (r0) return 0; [[fallthrough]];           \
 
 #define SEQ2_HELPER(s, r0, r1)                                 \
 case (s * 4) + 0: if (r0) return (s * 4) + 1; goto SEQ_END(s); \


### PR DESCRIPTION
When compiling with this version I got a number of warnings (aka errors) in the unit tests where the self assignment is checked:

```
tests/test-array.cc:156:5: error: explicitly assigning value of variable of type 'Json::Array' to itself
      [-Werror,-Wself-assign-overloaded]
        a5 = a5;
        ~~ ^ ~~
tests/test-object.cc:189:5: error: explicitly assigning value of variable of type 'Json::Object' to itself
      [-Werror,-Wself-assign-overloaded]
        o5 = o5;
        ~~ ^ ~~
tests/test-json.cc:108:5: error: explicitly assigning value of variable of type 'Json::Number' to itself
      [-Werror,-Wself-assign-overloaded]
        n1 = n1;
        ~~ ^ ~~
tests/test-json.cc:220:5: error: explicitly assigning value of variable of type 'Json::String' to itself
      [-Werror,-Wself-assign-overloaded]
        s1 = s1;
        ~~ ^ ~~

```

This commit attempts to fix this by using the according pragmas.