### PR TITLE
tests: Allow self-assignment of variables

### DIFF
--- a/tests/clang-helpers.h
+++ b/tests/clang-helpers.h
@@ -1,0 +1,19 @@
+#ifndef clang_helpers_h_
+#define clang_helpers_h_
+
+#if defined(__clang_major__) && __clang_major__ >= 6
+#define DONT_WARN_ABOUT_SELFASSIGNMENT \
+	do { \
+	_Pragma("clang diagnostic push"); \
+	_Pragma("clang diagnostic ignored \"-Wself-assign-overloaded\""); \
+	} while(0)
+#define WARN_ABOUT_SELFASSIGNMENT \
+	do { \
+	_Pragma("clang diagnostic pop"); \
+	} while(0)
+#else
+#define DONT_WARN_ABOUT_SELFASSIGNMENT do {} while(0)
+#define WARN_ABOUT_SELFASSIGNMENT do {} while(0)
+#endif
+
+#endif

--- a/tests/test-array.cc
+++ b/tests/test-array.cc
@@ -3,6 +3,8 @@
 
 #include <jsoncc-cppunit.h>
 
+#include "clang-helpers.h"
+
 namespace unittests {
 namespace json {
 namespace array {
@@ -150,7 +152,9 @@ void test::test_equality()
 	Json::Array a5;
 	a5 = a4;
 	CPPUNIT_ASSERT_EQUAL(a4, a5);
+	DONT_WARN_ABOUT_SELFASSIGNMENT;
 	a5 = a5;
+	WARN_ABOUT_SELFASSIGNMENT;
 	CPPUNIT_ASSERT_EQUAL(a4, a5);
 }
 

--- a/tests/test-json.cc
+++ b/tests/test-json.cc
@@ -2,6 +2,7 @@
 #include <jsoncc.h>
 
 #include <jsoncc-cppunit.h>
+#include "clang-helpers.h"
 
 namespace unittests {
 namespace json {
@@ -103,7 +104,9 @@ void test::test_number()
 	Json::Number n1;
 	n1 = n;
 	CPPUNIT_ASSERT_EQUAL(n, n1);
+	DONT_WARN_ABOUT_SELFASSIGNMENT;
 	n1 = n1;
+	WARN_ABOUT_SELFASSIGNMENT;
 	CPPUNIT_ASSERT_EQUAL(n, n1);
 }
 
@@ -213,7 +216,9 @@ void test::test_string()
 	Json::String s1;
 	s1 = s;
 	CPPUNIT_ASSERT_EQUAL(s, s1);
+	DONT_WARN_ABOUT_SELFASSIGNMENT;
 	s1 = s1;
+	WARN_ABOUT_SELFASSIGNMENT;
 	CPPUNIT_ASSERT_EQUAL(s, s1);
 }
 

--- a/tests/test-object.cc
+++ b/tests/test-object.cc
@@ -2,6 +2,7 @@
 #include <jsoncc.h>
 
 #include <jsoncc-cppunit.h>
+#include "clang-helpers.h"
 
 namespace unittests {
 namespace json {
@@ -183,7 +184,10 @@ void test::test_equality()
 	Json::Object o5;
 	o5 = o4;
 	CPPUNIT_ASSERT_EQUAL(o5, o4);
+
+	DONT_WARN_ABOUT_SELFASSIGNMENT;
 	o5 = o5;
+	WARN_ABOUT_SELFASSIGNMENT;
 	CPPUNIT_ASSERT_EQUAL(o5, o4);
 }
 


### PR DESCRIPTION
clang in version 7 (or later) warns about self-assignment with an
overloaded operator==. This -Wself-assignment-overloaded is enabled when
-Wall is given.

Add some call to the unit tests where the correct behaviour in the self
assignment is tested to avoid erroring the build there.

Fixes the following error messages:

tests/test-array.cc:156:5: error: explicitly assigning value of variable of type 'Json::Array' to itself
      [-Werror,-Wself-assign-overloaded]
        a5 = a5;
        ~~ ^ ~~
tests/test-object.cc:189:5: error: explicitly assigning value of variable of type 'Json::Object' to itself
      [-Werror,-Wself-assign-overloaded]
        o5 = o5;
        ~~ ^ ~~
tests/test-json.cc:108:5: error: explicitly assigning value of variable of type 'Json::Number' to itself
      [-Werror,-Wself-assign-overloaded]
        n1 = n1;
        ~~ ^ ~~
tests/test-json.cc:220:5: error: explicitly assigning value of variable of type 'Json::String' to itself
      [-Werror,-Wself-assign-overloaded]
        s1 = s1;
        ~~ ^ ~~